### PR TITLE
Accelerate subscriptions

### DIFF
--- a/src/Domain/Event/Subscription.php
+++ b/src/Domain/Event/Subscription.php
@@ -49,6 +49,8 @@ interface Subscription
      */
     public function restart() : void;
 
+    public function starting() : bool;
+
     public function started() : bool;
 
     public function completed() : bool;


### PR DESCRIPTION
Accelerate subscriptions but cutting replay time of their internal state.

Subscription itself do not need to replay all events - only "subscription started", "subscription restarted", "subscription completed" are needed and then single last "subscription listened to event" if exists.

Unfortunately listeners still need all events.