### PR TITLE
Subscription continuous listening

### DIFF
--- a/src/Domain/Event/Subscription.php
+++ b/src/Domain/Event/Subscription.php
@@ -36,7 +36,7 @@ interface Subscription
      * @throws Exception\SubscriptionAlreadyCompleted
      * @throws Exception\SubscriptionNotStartedYet
      */
-    public function subscribeTo(EventStore $store) : iterable;
+    public function subscribeTo(EventStore $store, int $limit) : iterable;
 
     /**
      * @param Domain\Event $event

--- a/src/Infrastructure/Event/Sourced/TransactionalSubscription.php
+++ b/src/Infrastructure/Event/Sourced/TransactionalSubscription.php
@@ -45,11 +45,11 @@ class TransactionalSubscription implements Subscription, Event\Sourced, Versiona
         return $this->subscription->listener();
     }
 
-    public function subscribeTo(EventStore $store) : iterable
+    public function subscribeTo(EventStore $store, int $limit) : iterable
     {
         try {
             $this->uow->add($this);
-            foreach ($this->subscription->subscribeTo($store) as $event) {
+            foreach ($this->subscription->subscribeTo($store, $limit) as $event) {
                 iterator_to_array($this->uow->commit());
                 $this->uow->add($this);
 

--- a/src/Infrastructure/Event/Subscription/LazyLoadedSubscription.php
+++ b/src/Infrastructure/Event/Subscription/LazyLoadedSubscription.php
@@ -43,9 +43,9 @@ class LazyLoadedSubscription implements Subscription
         return $this->subscription()->listener();
     }
 
-    public function subscribeTo(EventStore $store) : iterable
+    public function subscribeTo(EventStore $store, int $limit) : iterable
     {
-        yield from $this->subscription()->subscribeTo($store);
+        yield from $this->subscription()->subscribeTo($store, $limit);
     }
 
     public function startFor(Domain\Event $event) : void

--- a/tests/Infrastructure/Event/Sourced/SubscriptionTest.php
+++ b/tests/Infrastructure/Event/Sourced/SubscriptionTest.php
@@ -268,7 +268,7 @@ class SubscriptionTest extends TestCase
             ->method('completed')
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -280,7 +280,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -292,7 +292,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -371,7 +371,7 @@ class SubscriptionTest extends TestCase
             ->willReturn(true)
         ;
 
-        $events = $subscription->subscribeTo($this->store); // picker should pick $this->event2
+        $events = $subscription->subscribeTo($this->store, 2); // picker should pick $this->event2
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event2, $this->event3], $events);
@@ -393,7 +393,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(4, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store); // after restart picker should pick $this->event1
+        $events = $subscription->subscribeTo($this->store, 4); // after restart picker should pick $this->event1
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4], $events);
@@ -468,7 +468,7 @@ class SubscriptionTest extends TestCase
             ->willReturn(true)
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event2, $this->event3], $events);
@@ -480,7 +480,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event4, $this->event5], $events);
@@ -579,7 +579,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -591,7 +591,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -603,7 +603,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, PHP_INT_MAX); // subscription will stop listening to #events right after it being completed, even if $limit was not exhausted.
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -682,7 +682,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -694,7 +694,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -767,7 +767,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -779,7 +779,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -868,7 +868,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -880,7 +880,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(7, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -971,7 +971,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -983,7 +983,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(7, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -1085,7 +1085,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -1157,7 +1157,7 @@ class SubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionAlreadyCompleted($subscription));
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
 
         iterator_to_array($events);
     }
@@ -1194,7 +1194,7 @@ class SubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionAlreadyCompleted($subscription));
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
 
         iterator_to_array($events);
     }
@@ -1228,7 +1228,7 @@ class SubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionNotStartedYet($subscription));
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
 
         iterator_to_array($events);
     }
@@ -1309,7 +1309,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 4);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event1, $this->event3, $this->event4, $this->event5], $events);
@@ -1402,7 +1402,7 @@ class SubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 4);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event2, $this->event3, $this->event4, $this->event5], $events);
@@ -1525,7 +1525,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 4);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event2, $this->event3, $this->event4, $this->event5], $events);
@@ -1677,7 +1677,7 @@ class SubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1], $events);
@@ -1747,7 +1747,7 @@ class SubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1], $events);
@@ -1808,18 +1808,508 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
     }
 
-    private function isIteratorFor(MockObject &$iterator, array $items)
+    public function testNonPositiveLimitGivenWhileSubscribingToTheEventStoreBeforeStarting()
     {
-        $this->assertInstanceOf(\IteratorAggregate::class, $iterator);
+        $subscription = new Subscription($this->listener1, $this->clock);
 
-        $internal = new \ArrayIterator($items);
-
-        $iterator
-            ->expects($this->atLeastOnce())
-            ->method('getIterator')
-            ->willReturn($internal)
+        $this->store
+            ->expects($this->never())
+            ->method('stream')
         ;
 
-        return $iterator;
+        $this->listener1
+            ->expects($this->never())
+            ->method('on')
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $this->expectExceptionObject(new \InvalidArgumentException('$limit must be a positive integer, but 0 was given.'));
+
+        $events = $subscription->subscribeTo($this->store, 0);
+        $events->rewind();
+    }
+
+    public function testNonPositiveLimitGivenWhileSubscribingToTheEventStoreAfterStarting()
+    {
+        $subscription = new Subscription($this->listener1, $this->clock);
+        $subscription->startFor($this->event1);
+        $subscription->commit();
+
+        $this->store
+            ->expects($this->never())
+            ->method('stream')
+        ;
+
+        $this->listener1
+            ->expects($this->never())
+            ->method('on')
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $this->expectExceptionObject(new \InvalidArgumentException('$limit must be a positive integer, but -1 was given.'));
+
+        $events = $subscription->subscribeTo($this->store, -1);
+        $events->rewind();
+    }
+
+    public function testContinuousListeningWithNumberOfEventsBeingExactlyImposedLimit()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener1
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+        $this->listener1
+            ->expects($this->never())
+            ->method('replay')
+        ;
+
+        $subscription = new Subscription($this->listener1, $this->clock);
+
+        $this->assertSame($subscription->listener(), $this->listener1);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertNull($subscription->lastEvent());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4);
+        $this->stream3 = new InMemoryStream($this->event5);
+
+        $this->store
+            ->expects($this->exactly(3))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2,
+                $this->stream3
+            )
+        ;
+
+        $this->listener1
+            ->expects($this->exactly(5))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4],
+                [$this->event5]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 5);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4, $this->event5], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now), new SubscriptionListenedToEvent($this->event5, 6, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(6, $subscription->version());
+    }
+
+    public function testContinuousListeningWithNumberOfEventsBeingMoreThanImposedLimit1()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener1
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+        $this->listener1
+            ->expects($this->never())
+            ->method('replay')
+        ;
+
+        $subscription = new Subscription($this->listener1, $this->clock);
+
+        $this->assertSame($subscription->listener(), $this->listener1);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertNull($subscription->lastEvent());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4, $this->event5);
+
+        $this->store
+            ->expects($this->exactly(2))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2
+            )
+        ;
+
+        $this->listener1
+            ->expects($this->exactly(4))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 4);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(5, $subscription->version());
+    }
+
+    public function testContinuousListeningWithNumberOfEventsBeingMoreThanImposedLimit2()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener1
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+        $this->listener1
+            ->expects($this->never())
+            ->method('replay')
+        ;
+
+        $subscription = new Subscription($this->listener1, $this->clock);
+
+        $this->assertSame($subscription->listener(), $this->listener1);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertNull($subscription->lastEvent());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4);
+
+        $this->store
+            ->expects($this->exactly(2))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2
+            )
+        ;
+
+        $this->listener1
+            ->expects($this->exactly(4))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 4);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(5, $subscription->version());
+    }
+
+    public function testContinuousListeningWithNumberOfEventsBeingLessThanImposedLimit1()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener1
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+        $this->listener1
+            ->expects($this->never())
+            ->method('replay')
+        ;
+
+        $subscription = new Subscription($this->listener1, $this->clock);
+
+        $this->assertSame($subscription->listener(), $this->listener1);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertNull($subscription->lastEvent());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4, $this->event5);
+        $this->stream3 = new InMemoryStream();
+
+        $this->store
+            ->expects($this->exactly(3))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2,
+                $this->stream3
+            )
+        ;
+
+        $this->listener1
+            ->expects($this->exactly(5))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4],
+                [$this->event5]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 6);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4, $this->event5], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now), new SubscriptionListenedToEvent($this->event5, 6, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(6, $subscription->version());
+    }
+
+    public function testCompletingListenerWhileContinuousListening()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener3
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+
+        $subscription = new Subscription($this->listener3, $this->clock);
+
+        $this->assertSame($subscription->listener(), $this->listener3);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertNull($subscription->lastEvent());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals(new SubscriptionStarted($this->event1, $now), $subscription->lastEvent());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4);
+        $this->stream3 = new InMemoryStream($this->event5);
+
+        $this->store
+            ->expects($this->exactly(3))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2,
+                $this->stream3
+            )
+        ;
+
+        $this->listener3
+            ->expects($this->exactly(5))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4],
+                [$this->event5]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->exactly(5))
+            ->method('completed')
+            ->willReturnOnConsecutiveCalls(
+                false,
+                false,
+                false,
+                false,
+                true
+            )
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 6);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4, $this->event5], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now), new SubscriptionListenedToEvent($this->event5, 6, $now), new SubscriptionCompleted(7, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(7, $subscription->version());
     }
 }

--- a/tests/Infrastructure/Event/Sourced/TransactionalSubscriptionTest.php
+++ b/tests/Infrastructure/Event/Sourced/TransactionalSubscriptionTest.php
@@ -270,7 +270,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->method('completed')
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -288,7 +288,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertTrue($subscription->started());
         $this->assertFalse($subscription->completed());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -306,7 +306,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertTrue($subscription->started());
         $this->assertFalse($subscription->completed());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -406,7 +406,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->willReturn(true)
         ;
 
-        $events = $subscription->subscribeTo($this->store); // picker should pick $this->event2
+        $events = $subscription->subscribeTo($this->store, 2); // picker should pick $this->event2
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event2, $this->event3], $events);
@@ -437,7 +437,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertTrue($subscription->started());
         $this->assertFalse($subscription->completed());
 
-        $events = $subscription->subscribeTo($this->store); // after restart picker should pick $this->event1
+        $events = $subscription->subscribeTo($this->store, 4); // after restart picker should pick $this->event1
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4], $events);
@@ -526,7 +526,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->willReturn(true)
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event2, $this->event3], $events);
@@ -538,7 +538,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event4, $this->event5], $events);
@@ -645,7 +645,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -657,7 +657,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -669,7 +669,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, PHP_INT_MAX); // subscription will stop listening to #events right after it being completed, even if $limit was not exhausted.
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -757,7 +757,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -769,7 +769,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -851,7 +851,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -863,7 +863,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -982,7 +982,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 2);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -1072,7 +1072,7 @@ class TransactionalSubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionAlreadyCompleted($subscription));
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
 
         iterator_to_array($events);
     }
@@ -1119,7 +1119,7 @@ class TransactionalSubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionAlreadyCompleted($subscription));
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
 
         iterator_to_array($events);
     }
@@ -1163,7 +1163,7 @@ class TransactionalSubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionNotStartedYet($subscription));
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
 
         iterator_to_array($events);
     }
@@ -1250,7 +1250,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 4);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event1, $this->event3, $this->event4, $this->event5], $events);
@@ -1347,7 +1347,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 4);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event2, $this->event3, $this->event4, $this->event5], $events);
@@ -1485,7 +1485,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 4);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event2, $this->event3, $this->event4, $this->event5], $events);
@@ -1663,7 +1663,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1], $events);
@@ -1741,7 +1741,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store);
+        $events = $subscription->subscribeTo($this->store, 1);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1], $events);
@@ -1807,5 +1807,573 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertNull($subscription->lastReplayed());
         $this->assertSame(1, $subscription->version());
         $this->assertEquals([], $subscription->events());
+    }
+
+    public function testNonPositiveLimitGivenWhileSubscribingToTheEventStoreBeforeStarting()
+    {
+        $subscription = new Subscription($this->listener1, $this->clock);
+        $subscription = new TransactionalSubscription($subscription, $this->uow);
+
+        $this->uow
+            ->expects($this->never())
+            ->method('commit')
+        ;
+        $this->uow
+            ->expects($this->once())
+            ->method('add')
+            ->with($subscription)
+        ;
+
+        $this->store
+            ->expects($this->never())
+            ->method('stream')
+        ;
+
+        $this->listener1
+            ->expects($this->never())
+            ->method('on')
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $this->expectExceptionObject(new \InvalidArgumentException('$limit must be a positive integer, but 0 was given.'));
+
+        $events = $subscription->subscribeTo($this->store, 0);
+        $events->rewind();
+    }
+
+    public function testNonPositiveLimitGivenWhileSubscribingToTheEventStoreAfterStarting()
+    {
+        $subscription = new Subscription($this->listener1, $this->clock);
+        $subscription = new TransactionalSubscription($subscription, $this->uow);
+
+        $this->uow
+            ->expects($this->once())
+            ->method('commit')
+        ;
+        $this->uow
+            ->expects($this->exactly(2))
+            ->method('add')
+            ->with($subscription)
+        ;
+
+        $subscription->startFor($this->event1);
+        $subscription->commit();
+
+        $this->store
+            ->expects($this->never())
+            ->method('stream')
+        ;
+
+        $this->listener1
+            ->expects($this->never())
+            ->method('on')
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $this->expectExceptionObject(new \InvalidArgumentException('$limit must be a positive integer, but -1 was given.'));
+
+        $events = $subscription->subscribeTo($this->store, -1);
+        $events->rewind();
+    }
+
+    public function testContinuousListeningWithNumberOfEventsBeingExactlyImposedLimit()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener1
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+        $this->listener1
+            ->expects($this->never())
+            ->method('replay')
+        ;
+
+        $subscription = new Subscription($this->listener1, $this->clock);
+        $subscription = new TransactionalSubscription($subscription, $this->uow);
+
+        $this->uow
+            ->expects($this->exactly(7))
+            ->method('commit')
+        ;
+        $this->uow
+            ->expects($this->exactly(8))
+            ->method('add')
+            ->with($subscription)
+        ;
+
+        $this->assertSame($subscription->listener(), $this->listener1);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4);
+        $this->stream3 = new InMemoryStream($this->event5);
+
+        $this->store
+            ->expects($this->exactly(3))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2,
+                $this->stream3
+            )
+        ;
+
+        $this->listener1
+            ->expects($this->exactly(5))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4],
+                [$this->event5]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 5);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4, $this->event5], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now), new SubscriptionListenedToEvent($this->event5, 6, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(6, $subscription->version());
+    }
+
+    public function testContinuousListeningWithNumberOfEventsBeingMoreThanImposedLimit1()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener1
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+        $this->listener1
+            ->expects($this->never())
+            ->method('replay')
+        ;
+
+        $subscription = new Subscription($this->listener1, $this->clock);
+        $subscription = new TransactionalSubscription($subscription, $this->uow);
+
+        $this->uow
+            ->expects($this->exactly(6))
+            ->method('commit')
+        ;
+        $this->uow
+            ->expects($this->exactly(7))
+            ->method('add')
+            ->with($subscription)
+        ;
+
+        $this->assertSame($subscription->listener(), $this->listener1);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4, $this->event5);
+
+        $this->store
+            ->expects($this->exactly(2))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2
+            )
+        ;
+
+        $this->listener1
+            ->expects($this->exactly(4))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 4);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(5, $subscription->version());
+    }
+
+    public function testContinuousListeningWithNumberOfEventsBeingMoreThanImposedLimit2()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener1
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+        $this->listener1
+            ->expects($this->never())
+            ->method('replay')
+        ;
+
+        $subscription = new Subscription($this->listener1, $this->clock);
+        $subscription = new TransactionalSubscription($subscription, $this->uow);
+
+        $this->uow
+            ->expects($this->exactly(6))
+            ->method('commit')
+        ;
+        $this->uow
+            ->expects($this->exactly(7))
+            ->method('add')
+            ->with($subscription)
+        ;
+
+        $this->assertSame($subscription->listener(), $this->listener1);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4);
+
+        $this->store
+            ->expects($this->exactly(2))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2
+            )
+        ;
+
+        $this->listener1
+            ->expects($this->exactly(4))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 4);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(5, $subscription->version());
+    }
+
+    public function testContinuousListeningWithNumberOfEventsBeingLessThanImposedLimit1()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener1
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+        $this->listener1
+            ->expects($this->never())
+            ->method('replay')
+        ;
+
+        $subscription = new Subscription($this->listener1, $this->clock);
+        $subscription = new TransactionalSubscription($subscription, $this->uow);
+
+        $this->uow
+            ->expects($this->exactly(7))
+            ->method('commit')
+        ;
+        $this->uow
+            ->expects($this->exactly(8))
+            ->method('add')
+            ->with($subscription)
+        ;
+
+        $this->assertSame($subscription->listener(), $this->listener1);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4, $this->event5);
+        $this->stream3 = new InMemoryStream();
+
+        $this->store
+            ->expects($this->exactly(3))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2,
+                $this->stream3
+            )
+        ;
+
+        $this->listener1
+            ->expects($this->exactly(5))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4],
+                [$this->event5]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->never())
+            ->method('completed')
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 6);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4, $this->event5], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now), new SubscriptionListenedToEvent($this->event5, 6, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(6, $subscription->version());
+    }
+
+    public function testCompletingListenerWhileContinuousListening()
+    {
+        $now = new \DateTime('2018-09-28 19:12:32.763188 +00:00');
+
+        $this->listener3
+            ->expects($this->atLeastOnce())
+            ->method('listenerId')
+            ->willReturn($this->id1)
+        ;
+
+        $subscription = new Subscription($this->listener3, $this->clock);
+        $subscription = new TransactionalSubscription($subscription, $this->uow);
+
+        $this->uow
+            ->expects($this->exactly(7))
+            ->method('commit')
+        ;
+        $this->uow
+            ->expects($this->exactly(8))
+            ->method('add')
+            ->with($subscription)
+        ;
+
+        $this->assertSame($subscription->listener(), $this->listener3);
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertEmpty($subscription->events());
+        $this->assertSame(0, $subscription->version());
+
+        $subscription->startFor($this->event1);
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(0, $subscription->version());
+        $this->assertEquals([new SubscriptionStarted($this->event1, $now)], $subscription->events());
+
+        $subscription->commit();
+
+        $this->assertSame($this->id1, $subscription->subscriptionId());
+        $this->assertSame($this->id1, $subscription->producerId());
+        $this->assertNull($subscription->lastReplayed());
+        $this->assertSame(1, $subscription->version());
+        $this->assertEquals([], $subscription->events());
+
+        $this->stream1 = new InMemoryStream($this->event1, $this->event2);
+        $this->stream2 = new InMemoryStream($this->event3, $this->event4);
+        $this->stream3 = new InMemoryStream($this->event5);
+
+        $this->store
+            ->expects($this->exactly(3))
+            ->method('stream')
+            ->willReturnOnConsecutiveCalls(
+                $this->stream1,
+                $this->stream2,
+                $this->stream3
+            )
+        ;
+
+        $this->listener3
+            ->expects($this->exactly(5))
+            ->method('on')
+            ->withConsecutive(
+                [$this->event1],
+                [$this->event2],
+                [$this->event3],
+                [$this->event4],
+                [$this->event5]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                false,
+                true,
+                true
+            )
+        ;
+        $this->listener3
+            ->expects($this->exactly(5))
+            ->method('completed')
+            ->willReturnOnConsecutiveCalls(
+                false,
+                false,
+                false,
+                false,
+                true
+            )
+        ;
+
+        $events = $subscription->subscribeTo($this->store, 6);
+        $events = iterator_to_array($events);
+
+        $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4, $this->event5], $events);
+        $this->assertEquals([new SubscriptionListenedToEvent($this->event1, 2, $now), new SubscriptionIgnoredEvent($this->event2, 3, $now), new SubscriptionIgnoredEvent($this->event3, 4, $now), new SubscriptionListenedToEvent($this->event4, 5, $now), new SubscriptionListenedToEvent($this->event5, 6, $now), new SubscriptionCompleted(7, $now)], $subscription->events());
+        $this->assertSame(1, $subscription->version());
+
+        $subscription->commit();
+
+        $this->assertEquals([], $subscription->events());
+        $this->assertSame(7, $subscription->version());
     }
 }

--- a/tests/Infrastructure/Event/Subscription/LazyLoadedSubscriptionTest.php
+++ b/tests/Infrastructure/Event/Subscription/LazyLoadedSubscriptionTest.php
@@ -141,11 +141,11 @@ class LazyLoadedSubscriptionTest extends TestCase
         $this->subscription
             ->expects($this->once())
             ->method('subscribeTo')
-            ->with($this->store)
+            ->with($this->store, 94857623)
             ->willReturn([$this->event2, $this->event3])
         ;
 
-        $result = $subscription->subscribeTo($this->store);
+        $result = $subscription->subscribeTo($this->store, 94857623);
         $result = iterator_to_array($result);
 
         $this->assertSame([$this->event2, $this->event3], $result);


### PR DESCRIPTION
From now on `Subscription::subscribeTo(EventStore $store, int $limit)` will try to listen all events up to `$limit`.
Until now subscription listened to event found at the moment of subscribing ignoring event that were added to the event store after that.