### PR TITLE
if no limit is given for subscription, when subscribing to event store, then it will listen to initial stream only

### DIFF
--- a/src/Domain/Event/Subscription.php
+++ b/src/Domain/Event/Subscription.php
@@ -30,13 +30,14 @@ interface Subscription
 
     /**
      * @param EventStore $store
+     * @param int|null   $limit
      *
      * @return iterable|Domain\Event[]
      *
      * @throws Exception\SubscriptionAlreadyCompleted
      * @throws Exception\SubscriptionNotStartedYet
      */
-    public function subscribeTo(EventStore $store, int $limit) : iterable;
+    public function subscribeTo(EventStore $store, ?int $limit = null) : iterable;
 
     /**
      * @param Domain\Event $event

--- a/src/Infrastructure/Event/Sourced/TransactionalSubscription.php
+++ b/src/Infrastructure/Event/Sourced/TransactionalSubscription.php
@@ -45,7 +45,7 @@ class TransactionalSubscription implements Subscription, Event\Sourced, Versiona
         return $this->subscription->listener();
     }
 
-    public function subscribeTo(EventStore $store, int $limit) : iterable
+    public function subscribeTo(EventStore $store, ?int $limit = null) : iterable
     {
         try {
             $this->uow->add($this);

--- a/src/Infrastructure/Event/Subscription/LazyLoadedSubscription.php
+++ b/src/Infrastructure/Event/Subscription/LazyLoadedSubscription.php
@@ -43,7 +43,7 @@ class LazyLoadedSubscription implements Subscription
         return $this->subscription()->listener();
     }
 
-    public function subscribeTo(EventStore $store, int $limit) : iterable
+    public function subscribeTo(EventStore $store, ?int $limit = null) : iterable
     {
         yield from $this->subscription()->subscribeTo($store, $limit);
     }

--- a/tests/Infrastructure/Event/Sourced/SubscriptionTest.php
+++ b/tests/Infrastructure/Event/Sourced/SubscriptionTest.php
@@ -268,7 +268,7 @@ class SubscriptionTest extends TestCase
             ->method('completed')
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -280,7 +280,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -292,7 +292,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -371,7 +371,7 @@ class SubscriptionTest extends TestCase
             ->willReturn(true)
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2); // picker should pick $this->event2
+        $events = $subscription->subscribeTo($this->store); // picker should pick $this->event2
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event2, $this->event3], $events);
@@ -393,7 +393,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(4, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 4); // after restart picker should pick $this->event1
+        $events = $subscription->subscribeTo($this->store); // after restart picker should pick $this->event1
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4], $events);
@@ -468,7 +468,7 @@ class SubscriptionTest extends TestCase
             ->willReturn(true)
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event2, $this->event3], $events);
@@ -480,7 +480,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event4, $this->event5], $events);
@@ -579,7 +579,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -591,7 +591,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -682,7 +682,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -694,7 +694,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -767,7 +767,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -779,7 +779,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -868,7 +868,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -880,7 +880,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(7, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -971,7 +971,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -983,7 +983,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(7, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -1085,7 +1085,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -1157,7 +1157,7 @@ class SubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionAlreadyCompleted($subscription));
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
 
         iterator_to_array($events);
     }
@@ -1194,7 +1194,7 @@ class SubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionAlreadyCompleted($subscription));
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
 
         iterator_to_array($events);
     }
@@ -1228,7 +1228,7 @@ class SubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionNotStartedYet($subscription));
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
 
         iterator_to_array($events);
     }
@@ -1309,7 +1309,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 4);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event1, $this->event3, $this->event4, $this->event5], $events);
@@ -1402,7 +1402,7 @@ class SubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store, 4);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event2, $this->event3, $this->event4, $this->event5], $events);
@@ -1525,7 +1525,7 @@ class SubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 4);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event2, $this->event3, $this->event4, $this->event5], $events);
@@ -1677,7 +1677,7 @@ class SubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1], $events);
@@ -1747,7 +1747,7 @@ class SubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1], $events);

--- a/tests/Infrastructure/Event/Sourced/TransactionalSubscriptionTest.php
+++ b/tests/Infrastructure/Event/Sourced/TransactionalSubscriptionTest.php
@@ -270,7 +270,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->method('completed')
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -288,7 +288,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertTrue($subscription->started());
         $this->assertFalse($subscription->completed());
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -306,7 +306,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertTrue($subscription->started());
         $this->assertFalse($subscription->completed());
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -406,7 +406,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->willReturn(true)
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2); // picker should pick $this->event2
+        $events = $subscription->subscribeTo($this->store); // picker should pick $this->event2
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event2, $this->event3], $events);
@@ -437,7 +437,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertTrue($subscription->started());
         $this->assertFalse($subscription->completed());
 
-        $events = $subscription->subscribeTo($this->store, 4); // after restart picker should pick $this->event1
+        $events = $subscription->subscribeTo($this->store); // after restart picker should pick $this->event1
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2, $this->event3, $this->event4], $events);
@@ -526,7 +526,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->willReturn(true)
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event2, $this->event3], $events);
@@ -538,7 +538,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event4, $this->event5], $events);
@@ -645,7 +645,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -657,7 +657,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(3, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -757,7 +757,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -769,7 +769,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -851,7 +851,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event3, $this->event4], $events);
@@ -863,7 +863,7 @@ class TransactionalSubscriptionTest extends TestCase
         $this->assertEquals([], $subscription->events());
         $this->assertSame(5, $subscription->version());
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event5], $events);
@@ -982,7 +982,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 2);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1, $this->event2], $events);
@@ -1072,7 +1072,7 @@ class TransactionalSubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionAlreadyCompleted($subscription));
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
 
         iterator_to_array($events);
     }
@@ -1119,7 +1119,7 @@ class TransactionalSubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionAlreadyCompleted($subscription));
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
 
         iterator_to_array($events);
     }
@@ -1163,7 +1163,7 @@ class TransactionalSubscriptionTest extends TestCase
 
         $this->expectExceptionObject(new Event\Subscription\Exception\SubscriptionNotStartedYet($subscription));
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
 
         iterator_to_array($events);
     }
@@ -1250,7 +1250,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 4);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event1, $this->event3, $this->event4, $this->event5], $events);
@@ -1347,7 +1347,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store, 4);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event2, $this->event3, $this->event4, $this->event5], $events);
@@ -1485,7 +1485,7 @@ class TransactionalSubscriptionTest extends TestCase
             )
         ;
 
-        $events = $subscription->subscribeTo($this->store, 4);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertSame([$this->event2, $this->event3, $this->event4, $this->event5], $events);
@@ -1663,7 +1663,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1], $events);
@@ -1741,7 +1741,7 @@ class TransactionalSubscriptionTest extends TestCase
             ->method('reset')
         ;
 
-        $events = $subscription->subscribeTo($this->store, 1);
+        $events = $subscription->subscribeTo($this->store);
         $events = iterator_to_array($events);
 
         $this->assertEquals([$this->event1], $events);


### PR DESCRIPTION
it is a kind of fallback to original behaviour