### PR TITLE
dao should use subscription interface instead of concrete implementation

### DIFF
--- a/src/Infrastructure/Event/Envelope/Comparator.php
+++ b/src/Infrastructure/Event/Envelope/Comparator.php
@@ -42,12 +42,7 @@ class Comparator extends \SebastianBergmann\Comparator\Comparator
     {
         if ($expected instanceof Event\Envelope && $actual instanceof Event\Envelope) {
             if (false === $expected->equals($actual)) {
-                throw new ComparisonFailure(
-                    $expected,
-                    $actual,
-                    $expected->uuid()->toString(),
-                    $actual->uuid()->toString()
-                );
+                throw new ComparisonFailure($expected, $actual, $expected->uuid()->toString(), $actual->uuid()->toString());
             }
 
             return;

--- a/src/Infrastructure/Event/Sourced/Subscription.php
+++ b/src/Infrastructure/Event/Sourced/Subscription.php
@@ -175,8 +175,6 @@ final class Subscription implements Event\Subscription, Event\Sourced, Versionab
     /**
      * @see applySubscriptionStarted
      *
-     * @param Event\Envelope $event
-     *
      * @throws \Throwable
      */
     public function startFor(Event\Envelope $event) : void

--- a/src/Infrastructure/Event/Subscription/DAO.php
+++ b/src/Infrastructure/Event/Subscription/DAO.php
@@ -21,15 +21,14 @@ use Streak\Domain\Event\Subscription;
  */
 interface DAO
 {
-    public function save(DAO\Subscription $subscription) : void;
+    public function save(Subscription $subscription) : void;
 
     public function one(Listener\Id $id) : ?Subscription;
 
     public function exists(Listener\Id $id) : bool;
 
     /**
-     * @param string[]  $types
-     * @param bool|null $completed
+     * @param string[] $types
      *
      * @return DAO\Subscription[]
      */

--- a/src/Infrastructure/Event/Subscription/DAO/DbalPostgresDAO.php
+++ b/src/Infrastructure/Event/Subscription/DAO/DbalPostgresDAO.php
@@ -56,7 +56,7 @@ class DbalPostgresDAO implements DAO
         $this->converter = $converter;
     }
 
-    public function save(DAO\Subscription $subscription) : void
+    public function save(Subscription $subscription) : void
     {
         try {
             $this->doSave($subscription);
@@ -86,8 +86,7 @@ class DbalPostgresDAO implements DAO
     }
 
     /**
-     * @param string[]  $types
-     * @param bool|null $completed
+     * @param string[] $types
      *
      * @return Subscription[]
      */
@@ -333,10 +332,6 @@ SQL;
     }
 
     /**
-     * @param Listener\Id $id
-     *
-     * @return bool
-     *
      * @throws \Doctrine\DBAL\DBALException
      */
     private function doExists(Listener\Id $id) : bool
@@ -360,11 +355,6 @@ SQL;
     }
 
     /**
-     * @param array     $types
-     * @param bool|null $completed
-     *
-     * @return \Generator
-     *
      * @throws \Doctrine\DBAL\DBALException
      */
     private function doAll(array $types, ?bool $completed) : \Generator
@@ -409,11 +399,6 @@ SQL;
         $statement->closeCursor();
     }
 
-    /**
-     * @param Subscription $subscription
-     *
-     * @return DAO\Subscription
-     */
     private function unwrap(Subscription $subscription) : DAO\Subscription
     {
         $exception = new ObjectNotSupported($subscription);

--- a/src/Infrastructure/Event/Subscription/DAO/IdentityMappingDao.php
+++ b/src/Infrastructure/Event/Subscription/DAO/IdentityMappingDao.php
@@ -30,7 +30,7 @@ class IdentityMappingDao implements DAO
         $this->dao = $dao;
     }
 
-    public function save(DAO\Subscription $subscription) : void
+    public function save(Subscription $subscription) : void
     {
         if ($this->shouldSave($subscription)) {
             $this->dao->save($subscription);

--- a/src/Infrastructure/Event/Subscription/DAO/InMemoryDAO.php
+++ b/src/Infrastructure/Event/Subscription/DAO/InMemoryDAO.php
@@ -23,11 +23,11 @@ use Streak\Infrastructure\Event\Subscription\DAO;
 class InMemoryDAO implements DAO
 {
     /**
-     * @var DAO\Subscription[]
+     * @var Subscription[]
      */
     private $subscriptions = [];
 
-    public function save(DAO\Subscription $subscription) : void
+    public function save(Subscription $subscription) : void
     {
         foreach ($this->subscriptions as $key => $stored) {
             if ($stored->subscriptionId()->equals($subscription->subscriptionId())) {

--- a/src/Infrastructure/EventStore/DbalPostgresEventStore.php
+++ b/src/Infrastructure/EventStore/DbalPostgresEventStore.php
@@ -677,7 +677,7 @@ SQL;
         return $this->producerId($matches['type'], $matches['id']);
     }
 
-    private function extractIdForEventAlreadyInStore(UniqueConstraintViolationException $e) : UUID
+    private function extractIdForEventAlreadyInStore(UniqueConstraintViolationException $e)
     {
         // example:
         // SQLSTATE[23505]: Unique violation: 7 ERROR:  duplicate key value violates unique constraint "events_uuid_key"

--- a/src/Infrastructure/UnitOfWork/Exception/ObjectNotSupported.php
+++ b/src/Infrastructure/UnitOfWork/Exception/ObjectNotSupported.php
@@ -21,8 +21,7 @@ class ObjectNotSupported extends \RuntimeException
     private $object;
 
     /**
-     * @param object          $object
-     * @param \Throwable|null $previous
+     * @param object $object
      */
     public function __construct($object, \Throwable $previous = null)
     {

--- a/tests/Infrastructure/UnitOfWork/SubscriptionDAOUnitOfWorkTest.php
+++ b/tests/Infrastructure/UnitOfWork/SubscriptionDAOUnitOfWorkTest.php
@@ -59,6 +59,13 @@ class SubscriptionDAOUnitOfWorkTest extends TestCase
         $this->uow->add($subscription);
     }
 
+    public function testHasOnNotSupportedObject() : void
+    {
+        $subscription = $this->getMockBuilder(Subscription::class)->getMock();
+        self::expectException(ObjectNotSupported::class);
+        $this->uow->has($subscription);
+    }
+
     public function testItRemoves() : void
     {
         $subscription = $this->createSubscriptionStub('1');
@@ -113,6 +120,7 @@ class SubscriptionDAOUnitOfWorkTest extends TestCase
         /** @var Subscription\Decorator|MockObject $result */
         $result = $this->getMockBuilder([Subscription\Decorator::class, Subscription::class])->getMock();
         $result->expects($this->any())->method('subscription')->willReturn($this->createSubscriptionStub($id));
+        $result->expects($this->any())->method('subscriptionId')->willReturn($this->createIdStub($id));
 
         return $result;
     }


### PR DESCRIPTION
- dao should use subscription interface instead of concrete implementation
- fixed definition of DbalPostgresEventStore::extractIdForEventAlreadyInStore()
- updated php-cs-fixer