### PR TITLE
move subscribers to outside event bus (making it subscription itself) and others

### DIFF
--- a/src/Infrastructure/Application/Listener/Subscriber.php
+++ b/src/Infrastructure/Application/Listener/Subscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the streak package.
+ *
+ * (C) Alan Gabriel Bem <alan.bem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Streak\Infrastructure\Application\Listener;
+
+use Doctrine\DBAL\Connection;
+use Streak\Domain;
+use Streak\Domain\Event;
+use Streak\Domain\Event\Listener;
+
+class Subscriber implements Event\Listener
+{
+    use Event\Listener\Filtering;
+    use Event\Listener\Identifying;
+    use Event\Listener\Listening;
+    use Query\Handling;
+
+    public function __construct(Subscriber\Id $id)
+    {
+        $this->identifyBy($id);
+    }
+
+    public function listenerId(): Subscriber\Id
+    {
+        return $this->id;
+    }
+
+    public function on(Envelope $event): bool
+    {
+
+    }
+}

--- a/src/Infrastructure/Application/Listener/Subscriber/Id.php
+++ b/src/Infrastructure/Application/Listener/Subscriber/Id.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the streak package.
+ *
+ * (C) Alan Gabriel Bem <alan.bem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Streak\Infrastructure\Application\Listener\Subscriber;
+
+use Streak\Domain\Event\Listener;
+
+/**
+ * @see \Printify\Tests\Invoices\Application\Projectors\InvoicesList\Projector\IdTest
+ */
+final class Id implements Listener\Id
+{
+    private const ID = '00000000-0000-0000-0000-000000000000';
+
+    public function equals(object $id): bool
+    {
+        if (!$id instanceof self) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function toString(): string
+    {
+        return self::ID;
+    }
+
+    public static function fromString(string $id): self
+    {
+        return new self();
+    }
+}


### PR DESCRIPTION
- [ ] move subscribers to outside event bus (making it subscription itself)
- [ ] when unit of work is committed store all events from all registered aggregates at once